### PR TITLE
Dropped dependency on std.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,10 @@
 //! }
 //! ```
 
+#![no_std]
 
-use std::fmt;
-use std::fmt::Write;
+use core::fmt;
+use core::fmt::Write;
 
 pub struct Hex<'a, T: 'a>(&'a [T]);
 


### PR DESCRIPTION
This enables use of this crate in no_std projects.